### PR TITLE
fix: disable broken vercel app

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ I'm a full stack developer in Japan.
 
 [![GitHub Streak](https://github-readme-streak-stats-wheat-psi.vercel.app?user=tyler36&theme=dark&exclude_days=Sun%2CSat)](https://git.io/streak-stats)
 
-[![Tyler36's GitHub stats](https://github-readme-stats.vercel.app/api?username=tyler36&theme=dark&show_icons=true&rank_icon=percentile&count_private=true&show=prs_merged,prs_merged_percentage)](https://github-readme-stats.vercel.app/api?username=tyler36&show_icons=true&rank_icon=percentile&count_private=true&show=prs_merged,prs_merged_percentage)
+<!-- [![Tyler36's GitHub stats](https://github-readme-stats.vercel.app/api?username=tyler36&theme=dark&show_icons=true&rank_icon=percentile&count_private=true&show=prs_merged,prs_merged_percentage)](https://github-readme-stats.vercel.app/api?username=tyler36&show_icons=true&rank_icon=percentile&count_private=true&show=prs_merged,prs_merged_percentage) -->
 
-[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=tyler36&theme=dark&layout=compact)](https://github.com/tyler36/github-readme-stats)
+<!-- [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=tyler36&theme=dark&layout=compact)](https://github.com/tyler36/github-readme-stats) -->
 
 ## Tech Stacks
 


### PR DESCRIPTION
Commented out the broken links to the Vercel app in the README to prevent confusion for users.